### PR TITLE
free memory returned by CommandLineToArgvW after use

### DIFF
--- a/PyStand.cpp
+++ b/PyStand.cpp
@@ -95,6 +95,7 @@ bool PyStand::CheckEnviron(const wchar_t *rtp)
 	for (int i = 0; i < argc; i++) {
 		_argv[i] = argvw[i];
 	}
+	LocalFree(argvw);
 
 	// init: _cwd (current working directory)
 	wchar_t path[MAX_PATH + 10];


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw:
> CommandLineToArgvW allocates a block of contiguous memory for pointers to the argument strings, and for the argument strings themselves; the calling application must free the memory used by the argument list when it is no longer needed. To free the memory, use a single call to the [LocalFree](https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-localfree) function.