### PR TITLE
use binary reading to avoid encoding issues

### DIFF
--- a/PyStand.cpp
+++ b/PyStand.cpp
@@ -320,7 +320,7 @@ const char *init_script =
 "    if os.path.exists(test): sys.path.append(test)\n"
 "sys.path.append(os.path.abspath(PYSTAND_HOME))\n"
 "sys.argv = [PYSTAND_SCRIPT] + sys.argv[1:]\n"
-"text = open(PYSTAND_SCRIPT).read()\n"
+"text = open(PYSTAND_SCRIPT, 'rb').read()\n"
 "environ = {'__file__': PYSTAND_SCRIPT, '__name__': '__main__'}\n"
 "environ['__package__'] = None\n"
 "exec(text, environ)\n"

--- a/PyStand.cpp
+++ b/PyStand.cpp
@@ -321,9 +321,10 @@ const char *init_script =
 "sys.path.append(os.path.abspath(PYSTAND_HOME))\n"
 "sys.argv = [PYSTAND_SCRIPT] + sys.argv[1:]\n"
 "text = open(PYSTAND_SCRIPT, 'rb').read()\n"
+"code = compile(text, PYSTAND_SCRIPT, 'exec')\n"
 "environ = {'__file__': PYSTAND_SCRIPT, '__name__': '__main__'}\n"
 "environ['__package__'] = None\n"
-"exec(text, environ)\n"
+"exec(code, environ)\n"
 "";
 
 


### PR DESCRIPTION
在本地编码是 GBK 编码的情况下，如果 `PYSTAND_SCRIPT` 使用 UTF-8 编码并包含非 ASCII 字符，可能导致脚本调用失败。

示例一：
```python
#!/usr/bin/env python3
# coding: utf-8

print('你好，世界！')
```
该例子显示中文乱码。

示例二：
```python
#!/usr/bin/env python3
# coding: utf-8

print('文章简介')
```
该例子抛出 `UnicodeDecodeError` 异常。

实际上 #2 也提到另外一种做法：可以将这些放在另外一个脚本里，并在 `PYSTAND_SCRIPT` import 之。

也可以先 compile 再 exec：
> ```python
> def exec_full(filepath):
>     global_namespace = {
>         "__file__": filepath,
>         "__name__": "__main__",
>     }
>     with open(filepath, 'rb') as file:
>         exec(compile(file.read(), filepath, 'exec'), global_namespace)
> 
> # Execute the file.
> exec_full("/path/to/somefile.py")
> ```

另一种解决方案是始终使用 `utf-8` 打开文件（毕竟，`utf-8` 编码已被很多人接受）。
```python
text = open(PYSTAND_SCRIPT, 'r', encoding='utf-8').read()
```

参考：
- [Alternative to execfile in Python 3?](https://stackoverflow.com/questions/6357361/alternative-to-execfile-in-python-3)
- [What's the difference between eval, exec, and compile?](https://stackoverflow.com/questions/2220699/whats-the-difference-between-eval-exec-and-compile)