### PR TITLE
fix assertion failure in vs2010

### DIFF
--- a/PyStand.cpp
+++ b/PyStand.cpp
@@ -260,7 +260,7 @@ int PyStand::RunString(const char *script)
 int PyStand::DetectScript()
 {
 	// init: _script (init script like PyStand.int or PyStand.py)
-	int size = (int)_pystand.size();
+	int size = (int)_pystand.size() - 1;
 	for (; size > 0; size--) {
 		if (_pystand[size] == L'.') break;
 	}


### PR DESCRIPTION
在 VS2010 SP1 中测试发现，如下代码中，第一次迭代在 Debug 模式下会引发断言失败：
```cpp
int size = (int)_pystand.size();
for (; size > 0; size--) {
	if (_pystand[size] == L'.') break;
}
```

SO 上有个问题：[Does std::string have a null terminator?](https://stackoverflow.com/questions/11752705/does-stdstring-have-a-null-terminator)
> Not in C++03, and it's not even guaranteed before C++11 that in a C++ std::string is continuous in memory. Only C strings (char arrays which are intended for storing strings) had the null terminator.
>
> In C++11 and later, mystring.c_str() is equivalent to mystring.data() is equivalent to &mystring[0], and mystring[mystring.size()] is guaranteed to be '\0'.

实际上，即使在 VS2022 中，在变量监视器里输入 `_pystand[size]` 也会看到一条警告信息：
![out_of_range](https://user-images.githubusercontent.com/5435649/210780988-305007d1-f067-4968-a1a7-626761076fec.png)

为了提升对一些旧版本编译器的兼容性，可以考虑在迭代前先减去 1。

另外一种修复方案是使用 [PathFindExtensionW](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-pathfindextensiona)。
