### PR TITLE
improve file extension removal

### DIFF
--- a/PyStand.cpp
+++ b/PyStand.cpp
@@ -260,22 +260,9 @@ int PyStand::RunString(const char *script)
 int PyStand::DetectScript()
 {
 	// init: _script (init script like PyStand.int or PyStand.py)
-#if 0
-	int size = (int)_pystand.size() - 1;
-	for (; size >= 0; size--) {
-		if (_pystand[size] == L'.') break;
-		else if (_pystand[size] == L'\\' || _pystand[size] == L'/') {
-			size = -1;
-			break;
-		}
-	}
-	if (size < 0) size = (int)_pystand.size();
-	std::wstring main = _pystand.substr(0, size);
-#else
 	const wchar_t *start = _pystand.c_str();
 	const wchar_t *ext = PathFindExtensionW(start);
 	std::wstring main = _pystand.substr(0, ext - start);
-#endif
 	std::vector<const wchar_t*> exts;
 	std::vector<std::wstring> scripts;
 	exts.push_back(L".int");

--- a/PyStand.cpp
+++ b/PyStand.cpp
@@ -260,12 +260,22 @@ int PyStand::RunString(const char *script)
 int PyStand::DetectScript()
 {
 	// init: _script (init script like PyStand.int or PyStand.py)
+#if 0
 	int size = (int)_pystand.size() - 1;
 	for (; size >= 0; size--) {
 		if (_pystand[size] == L'.') break;
+		else if (_pystand[size] == L'\\' || _pystand[size] == L'/') {
+			size = -1;
+			break;
+		}
 	}
 	if (size < 0) size = (int)_pystand.size();
 	std::wstring main = _pystand.substr(0, size);
+#else
+	const wchar_t *start = _pystand.c_str();
+	const wchar_t *ext = PathFindExtensionW(start);
+	std::wstring main = _pystand.substr(0, ext - start);
+#endif
 	std::vector<const wchar_t*> exts;
 	std::vector<std::wstring> scripts;
 	exts.push_back(L".int");


### PR DESCRIPTION
见：https://github.com/skywind3000/PyStand/pull/30#issuecomment-1374684514

本补丁提出了两种改进方式（最终可能会选用其一）：

1. 在查找扩展名的时候，如果遇到路径分隔符，跳出循环；
2. 使用 [PathFindExtensionW](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-pathfindextensionw);

    如果 `PathFindExtensionW` 找到了扩展名，则其返回指向扩展名起始 `.` 的指针；如果没找到扩展名，则其返回指向终末 `\0` 的指针。
