### PR TITLE
refactor Ansi2Unicode

### DIFF
--- a/PyStand.cpp
+++ b/PyStand.cpp
@@ -68,12 +68,12 @@ PyStand::PyStand(const char *runtime)
 //---------------------------------------------------------------------
 std::wstring PyStand::Ansi2Unicode(const char *text)
 {
-	int require = (int)strlen(text) * 2 + 10;
 	std::wstring wide;
-	wide.resize(require + 2);
-	MultiByteToWideChar(CP_ACP, 0, text, -1, &wide[0], require);
-	int size = wcslen(wide.c_str());
-	wide.resize(size);
+	int require = MultiByteToWideChar(CP_ACP, 0, text, -1, NULL, 0);
+	if (require > 0) {
+		wide.resize(require);
+		MultiByteToWideChar(CP_ACP, 0, text, -1, &wide[0], require);
+	}
 	return wide;
 }
 


### PR DESCRIPTION
修改的动机：

原来的实现里：

```cpp
int size = wcslen(wide.c_str());
```

会触发一个告警信息。于是我就想消除它。我考虑了：

```cpp
int size = (int)wcslen(wide.c_str());
```

但又想，这里要不要 +1 以保留 `\0` 呢？（虽然，后面通过 `.c_str()` 总是能确保得到一个以 `\0` 结尾的字符串。）

```cpp
int size = wcslen(wide.c_str()) + 1;
wide.resize(size);
```

纠结之下，便决定重构一下。

修改后的版本，也能够减少不必要的内存分配。

以：

```cpp
Ansi2Unicode("runtime");
```
为例，修改前，计算得的 require 为 26，修改后的为 8。

参考：

- [MultiByteToWideChar](https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar)
- [How do I use MultiByteToWideChar?](https://stackoverflow.com/questions/6693010/how-do-i-use-multibytetowidechar)
- :star: [wchar_helper.hpp](https://github.com/xqq/libaribcaption/blob/master/src/base/wchar_helper.hpp)
- https://github.com/pbatard/libwdi/blob/67226813462162fba99ed260c88d812181bd27b6/libwdi/msapi_utf8.h#L112