### PR TITLE
fix #38

### DIFF
--- a/PyStand.cpp
+++ b/PyStand.cpp
@@ -323,7 +323,9 @@ const char *init_script =
 "    sys.stdout = fp\n"
 "    sys.stderr = fp\n"
 "except Exception as e:\n"
-"    pass\n"
+"    fp = open(os.devnull, 'w')\n"
+"    sys.stdout = fp\n"
+"    sys.stderr = fp\n"
 #endif
 "for n in ['.', 'lib', 'site-packages']:\n"
 "    test = os.path.abspath(os.path.join(PYSTAND_HOME, n))\n"


### PR DESCRIPTION
在重定向 stdout & stderr 失败的时候，尝试将它们重定向至 devnull。这样，即使用户代码里有诸如：

```python
stdout.write(...)
```

这样的代码，程序依然能正常运行下去。

参考：[Redirecting stdout to "nothing" in python](https://stackoverflow.com/questions/6735917/redirecting-stdout-to-nothing-in-python)
