### PR TITLE
修复非中文系统下print中文字符导致崩溃

### DIFF
--- a/PyStand.cpp
+++ b/PyStand.cpp
@@ -343,7 +343,7 @@ const char *init_script =
 "    sys.stderr = fp\n"
 "    attached = True\n"
 "except Exception as e:\n"
-"    fp = open(os.devnull, 'w')\n"
+"    fp = open(os.devnull, 'w', errors='ignore')\n"
 "    sys.stdout = fp\n"
 "    sys.stderr = fp\n"
 "    attached = False\n"


### PR DESCRIPTION
open 'w'若不指定编码，会使用默认代码页，导致崩溃。
