### PR TITLE
fix loadlibrary error

### DIFF
--- a/PyStand.cpp
+++ b/PyStand.cpp
@@ -194,8 +194,9 @@ bool PyStand::LoadPython()
 	SetCurrentDirectoryW(runtime.c_str());
 	SetDllDirectoryW(runtime.c_str());
 
+	auto pydll = runtime + L"\\python3.dll";
 	// LoadLibrary
-	_hDLL = (HINSTANCE)LoadLibraryA("python3.dll");
+	_hDLL = (HINSTANCE)LoadLibraryW(pydll.c_str());
 	if (_hDLL) {
 		_Py_Main = (t_Py_Main)GetProcAddress(_hDLL, "Py_Main");
 	}
@@ -210,7 +211,7 @@ bool PyStand::LoadPython()
 	}
 	else if (_Py_Main == NULL) {
 		std::wstring msg = L"Cannot find Py_Main() in:\r\n";
-		msg += runtime + L"\\python3.dll";
+		msg += pydll;
 		MessageBoxW(NULL, msg.c_str(), L"ERROR", MB_OK);
 		return false;
 	}


### PR DESCRIPTION
当system32中存在python3.dll时，即使SetDllDirectoryW也仍会优先加载system32中的dll，导致直接崩溃。

[issues/99](https://github.com/skywind3000/PyStand/issues/99)可能也是这个原因。和网上说的pythonpath&pthonhome等等环境变量都没关系。

![QQ图片20250329181438](https://github.com/user-attachments/assets/49613196-93ad-4483-8a42-b189ba025ce9)
