### PR TITLE
fix CMake deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project (PyStand LANGUAGES CXX RC)
 


### PR DESCRIPTION
在 CMake 3.27+ 中，项目指定低于 3.5 的 CMake 版本会触发警告。
在 CMake 4.0 中，项目指定低于 3.10 的 CMake 版本会触发警告。

目前，GitHub Actions 中的 CMake 版本较新，在使用 CMake 3.5 的时候会触发一条警告：

![图片](https://github.com/user-attachments/assets/f602e43c-2253-4531-a75f-8a4fbe13f53c)

本 PR 按照 CMake 警告中提示的做法对 CMake 版本进行调整，在保留了对老版本 CMake 支持的同时，消除这条警告。
