### PR TITLE
update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
 
 env:
   BUILD_TYPE: Release
@@ -13,7 +16,10 @@ jobs:
     if: >-
       github.event.pull_request.draft == false
 
-    runs-on: windows-latest
+    runs-on: windows-2022
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -25,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7.0.1
 
     - name: Configure
       run: >
@@ -40,7 +46,7 @@ jobs:
         cmake --build build --config ${{ env.BUILD_TYPE }}
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: PyStand-${{ matrix.arch }}-${{ matrix.subsystem }}
         path: build/${{ env.BUILD_TYPE }}
@@ -59,7 +65,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7.0.1
 
     - name: Setup WinLibs
       run: |
@@ -87,21 +93,24 @@ jobs:
         cmake --build build --config ${{ env.BUILD_TYPE }}
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: PyStand-${{ matrix.sys }}-${{ matrix.subsystem }}
         path: build\PyStand.exe
 
   release:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'release'
 
     runs-on: windows-latest
 
     needs: [ build-msvc, build-gcc ]
 
+    permissions:
+      contents: write
+
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.1
 
     - name: List downloaded files
       run: ls -R
@@ -121,7 +130,7 @@ jobs:
         PyStand-mingw64-GUI
 
     - name: Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
本 PR：

1. windows-latest/windows-2025 镜像上的 Visual Studio 已经升级到了 [2026](https://github.com/actions/runner-images/issues/14017)，2022 不可用，导致编译失败；
    - 可选的修复方案就是将 generator 改成：Visual Studio 18 2026；
    - 另外一种可选的方案就是不指定 generator，始终使用最新版的 Visual Studio；
3. 更新 GitHub Actions 到最新版本；
4. 明确指定 permissions；
5. 调整发布方式：
   - 旧版本：添加 tag 并 push tag 就发布；
   - 新版本：在 GitHub Releases 页面手动发布；

