### PR TITLE
fix CodeQL code scanning warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,15 @@ on:
 env:
   BUILD_TYPE: Release
 
+permissions:
+  contents: read
+
 jobs:
   build-msvc:
     if: >-
       github.event.pull_request.draft == false
 
     runs-on: windows-2022
-
-    permissions:
-      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
在 #112 中，忘记给 build-gcc 这个 job 设置 permissions 了，导致 CodeQL code scanning 还有一个 warning 没消除（需要开启/配置 CodeQL code scanning 才可以看到）：

<img width="1504" height="1278" alt="CodeQL warning" src="https://github.com/user-attachments/assets/1037819b-450a-438e-8789-eeae6b90e9e3" />

本 PR 把设置在 build-msvc 上的 permission 挪至顶端，以便于应用到 build-msvc、build-gcc 两个 jobs（release job 已单独设置了 write 权限，会覆盖这个全局的权限）。
